### PR TITLE
fixed: private key is never closed

### DIFF
--- a/pyhids/genKeys.py
+++ b/pyhids/genKeys.py
@@ -19,7 +19,7 @@ def main(nb_bits: int = 1024):
     pickle.dump(priv, private_key)
 
     public_key.close()
-    public_key.close()
+    private_key.close()
 
     print("Done.")
 


### PR DESCRIPTION
I noticed that the public key file is closed twice and private isn't closed.